### PR TITLE
Link DisplayAnchors type; add usage comment

### DIFF
--- a/3 classes/View.DisplaySprite.html
+++ b/3 classes/View.DisplaySprite.html
@@ -460,7 +460,7 @@
     <h3>Returns:</h3>
     <ol>
 
-           <span class="types"><span class="type">DisplayAnchors</span></span>
+           <span class="types"><a class="type" href="../4 primitive classes/View.DisplayAnchors.html#">DisplayAnchors</a></span>
          An object containing the anchor points of the display sprite.<br>
  The object contains the following fields:<br>
  - <code>TOP_LEFT</code><br>

--- a/4 primitive classes/View.DisplayAnchors.html
+++ b/4 primitive classes/View.DisplayAnchors.html
@@ -346,7 +346,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">This</span>
-            <span class="types"><span class="type">DisplayAnchors</span></span>
+            <span class="types"><a class="type" href="../4 primitive classes/View.DisplayAnchors.html#">DisplayAnchors</a></span>
          DisplayAnchors.
         </li>
     </ul>
@@ -362,7 +362,8 @@
 
     <h3>Usage:</h3>
     <ul>
-        <pre class="example"><span class="keyword">local</span> anchors = TEN.View.DisplayAnchors()
+        <pre class="example"><span class="comment">-- Generate generic anchors object with default values.
+</span><span class="keyword">local</span> anchors = TEN.View.DisplayAnchors()
 <span class="global">print</span>(<span class="global">tostring</span>(anchors))
 <span class="comment">-- or --
 </span><span class="global">print</span>(anchors)


### PR DESCRIPTION
This pull request makes small improvements to the documentation for the `DisplayAnchors` class and related usage examples. The changes primarily enhance clarity and add helpful links for easier navigation.

Documentation and linking improvements:

* Added a hyperlink to the `DisplayAnchors` type in the parameters and return sections of both `View.DisplaySprite` and `View.DisplayAnchors` documentation, making it easier to navigate to the relevant class description.
* Updated the usage example in `View.DisplayAnchors` documentation to include a clarifying comment about generating a generic anchors object with default values.